### PR TITLE
Add mocked authentication and session flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "dotenv": "^17.4.2",
+    "jose": "^6.2.3",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "prisma": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
@@ -2015,6 +2018,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4998,6 +5004,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,0 +1,7 @@
+import { deleteSession } from "@/lib/session";
+import { redirect } from "next/navigation";
+
+export async function logout() {
+  await deleteSession();
+  redirect("/");
+}

--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -1,0 +1,12 @@
+import { createSession } from "@/lib/session";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  // Mock ignore 'code' argument
+
+  // Create a new session
+  console.log("creating session");
+  await createSession("Testu", "Exempelsson");
+
+  return NextResponse.redirect(new URL("/admin", req.url));
+}

--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -1,12 +1,11 @@
 import { createSession } from "@/lib/session";
 import { NextRequest, NextResponse } from "next/server";
 
+// Mocked callback route. Creates a new session without authentication.
 export async function GET(req: NextRequest) {
-  // Mock ignore 'code' argument
-
   // Create a new session
-  console.log("creating session");
   await createSession("Testu", "Exempelsson");
 
+  // Redirect to the admin dashboard
   return NextResponse.redirect(new URL("/admin", req.url));
 }

--- a/src/app/login/route.ts
+++ b/src/app/login/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// Mocked login route. Redirects directly to the callback instead of a login page.
 export function GET(req: NextRequest) {
-  // Mock redirect directly to callback instead of login page.
   return NextResponse.redirect(new URL("/callback", req.url));
 }

--- a/src/app/login/route.ts
+++ b/src/app/login/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function GET(req: NextRequest) {
+  // Mock redirect directly to callback instead of login page.
+  return NextResponse.redirect(new URL("/callback", req.url));
+}

--- a/src/app/logout/route.ts
+++ b/src/app/logout/route.ts
@@ -1,0 +1,7 @@
+import { deleteSession } from "@/lib/session";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  await deleteSession();
+  return NextResponse.redirect(new URL("/", req.url));
+}

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+type Props = {
+  children?: ReactNode;
+};
+
+export function LoginButton({ children }: Props) {
+  return (
+    <Link
+      className="bg-amber-light m-2 rounded-[14px] p-2 font-serif"
+      href="/oauth2/authorize"
+    >
+      {children ?? "Login"}
+    </Link>
+  );
+}

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -7,10 +7,7 @@ type Props = {
 
 export function LoginButton({ children }: Props) {
   return (
-    <Link
-      className="bg-amber-light m-2 rounded-[14px] p-2 font-serif"
-      href="/login"
-    >
+    <Link className="text-ink font-serif" href="/login">
       {children ?? "Login"}
     </Link>
   );

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -9,7 +9,7 @@ export function LoginButton({ children }: Props) {
   return (
     <Link
       className="bg-amber-light m-2 rounded-[14px] p-2 font-serif"
-      href="/oauth2/authorize"
+      href="/login"
     >
       {children ?? "Login"}
     </Link>

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+type Props = {
+  children?: ReactNode;
+};
+
+export function LogoutButton({ children }: Props) {
+  return (
+    <Link className="text-ink font-serif" href="/logout">
+      {children ?? "Logout"}
+    </Link>
+  );
+}

--- a/src/components/feed/FeedHeader.tsx
+++ b/src/components/feed/FeedHeader.tsx
@@ -1,4 +1,5 @@
 import { Wordmark } from "@/components/brand/Wordmark";
+import { LoginButton } from "@/components/LoginButton";
 import { FOCUS_RING } from "@/lib/styles";
 import Link from "next/link";
 
@@ -13,6 +14,7 @@ export function FeedHeader() {
         >
           <Wordmark size={20} />
         </Link>
+        <LoginButton />
       </div>
     </header>
   );

--- a/src/components/feed/FeedHeader.tsx
+++ b/src/components/feed/FeedHeader.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 export function FeedHeader() {
   return (
     <header className="border-ink/10 bg-paper supports-[backdrop-filter]:bg-paper/70 sticky top-0 z-30 border-b pt-[env(safe-area-inset-top)] backdrop-blur-md">
-      <div className="mx-auto flex h-14 max-w-screen-sm items-center px-4">
+      <div className="mx-auto flex h-14 max-w-screen-sm items-center justify-between px-4">
         <Link
           href="/"
           aria-label="Don't Spill the Tea — home"

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,120 @@
+// Mostly copied from https://nextjs.org/docs/app/guides/authentication
+
+import "server-only";
+import { JWTPayload, jwtVerify, SignJWT } from "jose";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { cache } from "react";
+
+export interface SessionPayload extends JWTPayload {
+  given_name: string;
+  family_name: string;
+  exp: number;
+}
+
+// Mock authentication does not require a secure secret
+const secretKey = "my-secret";
+const encodedKey = new TextEncoder().encode(secretKey);
+
+/**
+ * Encrypt a session as a JWT.
+ * @param payload The JWT payload and expiration timestamp.
+ * @returns The signed JWT string.
+ */
+export async function encrypt(payload: SessionPayload) {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(payload.exp)
+    .sign(encodedKey);
+}
+
+/**
+ * Verify and decrypt a JWT session.
+ * @param session The JWT string.
+ * @returns The decrypted session.
+ */
+export async function decrypt(
+  session: string | undefined = ""
+): Promise<SessionPayload | undefined> {
+  try {
+    const { payload } = await jwtVerify(session, encodedKey, {
+      algorithms: ["HS256"],
+    });
+    return payload as SessionPayload;
+  } catch {
+    console.log("Failed to verify session");
+  }
+}
+
+export async function createSession(firstName: string, lastName: string) {
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const expiresAtSeconds = expiresAt.getTime() / 1000;
+  console.log("encrypting");
+  const session = await encrypt({
+    given_name: firstName,
+    family_name: lastName,
+    exp: expiresAtSeconds,
+  });
+  console.log("getting store");
+  const cookieStore = await cookies();
+
+  console.log("setting session");
+  cookieStore.set("session", session, {
+    httpOnly: true,
+    secure: true,
+    expires: expiresAt,
+    sameSite: "lax",
+    path: "/",
+  });
+}
+
+export async function updateSession() {
+  const session = (await cookies()).get("session")?.value;
+  const payload = await decrypt(session);
+
+  if (!session || !payload) {
+    return null;
+  }
+
+  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  const cookieStore = await cookies();
+  cookieStore.set("session", session, {
+    httpOnly: true,
+    secure: true,
+    expires: expires,
+    sameSite: "lax",
+    path: "/",
+  });
+}
+
+export async function deleteSession() {
+  const cookieStore = await cookies();
+  cookieStore.delete("session");
+}
+
+/**
+ * Verify that the session stored in the cookie is valid and redirect to
+ * the login page if not.
+ *
+ * Protected server actions should call this function before processing
+ * requests.
+ *
+ * @return The session if it exists and is valid.
+ */
+export const verifySession = cache(
+  async (): Promise<SessionPayload | never> => {
+    const cookie = (await cookies()).get("session")?.value;
+    const session = (await decrypt(cookie)) as SessionPayload | undefined;
+
+    // Check if session does not exist or has expired
+    const currentTimeSeconds = Date.now() / 1000;
+    if (session?.exp == undefined || session.exp <= currentTimeSeconds) {
+      // Mock redirect to homepage instead of login
+      redirect("/");
+    }
+
+    return session;
+  }
+);

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -6,15 +6,23 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
+/** Properties stored in the session token. */
 export interface SessionPayload extends JWTPayload {
+  /** First name of the user. */
   given_name: string;
+  /** Last name of the user. */
   family_name: string;
+  /** Expiration time of the session cookie as a timestamp in seconds. */
   exp: number;
 }
 
-// Mock authentication does not require a secure secret
+// The mocked authentication does not require a secure secret since it does not
+// intend to offer any actual security
 const secretKey = "my-secret";
 const encodedKey = new TextEncoder().encode(secretKey);
+
+/** Time before a session expires in milliseconds. */
+const sessionExpireAfter = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 
 /**
  * Encrypt a session as a JWT.
@@ -47,19 +55,25 @@ export async function decrypt(
   }
 }
 
+/**
+ * Create a new session for an authenticated user.
+ * @param firstName First name of the user.
+ * @param firstName Last name of the user.
+ */
 export async function createSession(firstName: string, lastName: string) {
-  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  // Calculate the session expiration
+  const expiresAt = new Date(Date.now() + sessionExpireAfter);
   const expiresAtSeconds = expiresAt.getTime() / 1000;
-  console.log("encrypting");
+
+  // Create a new session
   const session = await encrypt({
     given_name: firstName,
     family_name: lastName,
     exp: expiresAtSeconds,
   });
-  console.log("getting store");
-  const cookieStore = await cookies();
 
-  console.log("setting session");
+  // Store the session in a cookie
+  const cookieStore = await cookies();
   cookieStore.set("session", session, {
     httpOnly: true,
     secure: true,
@@ -69,7 +83,12 @@ export async function createSession(firstName: string, lastName: string) {
   });
 }
 
+/**
+ * Update the current session to extend the cookie expiration time.
+ * Note that the token will still expire in the same time.
+ */
 export async function updateSession() {
+  // Get the current session
   const session = (await cookies()).get("session")?.value;
   const payload = await decrypt(session);
 
@@ -77,18 +96,23 @@ export async function updateSession() {
     return null;
   }
 
-  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  // Calculate the new expiration
+  const expiresAt = new Date(Date.now() + sessionExpireAfter);
 
+  // Create a new session with the new expiration time.
   const cookieStore = await cookies();
   cookieStore.set("session", session, {
     httpOnly: true,
     secure: true,
-    expires: expires,
+    expires: expiresAt,
     sameSite: "lax",
     path: "/",
   });
 }
 
+/**
+ * Delete the current session cookie, leaving the user unauthenticated.
+ */
 export async function deleteSession() {
   const cookieStore = await cookies();
   cookieStore.delete("session");
@@ -111,7 +135,9 @@ export const verifySession = cache(
     // Check if session does not exist or has expired
     const currentTimeSeconds = Date.now() / 1000;
     if (session?.exp == undefined || session.exp <= currentTimeSeconds) {
-      // Mock redirect to homepage instead of login
+      // The mocked authentication redirects to the homepage instead of the
+      // login page since the mocked login would instantly re-authenticate
+      // the user.
       redirect("/");
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,38 @@
+import { verifySession } from "@/lib/session";
+import { NextRequest, NextResponse } from "next/server";
+
+const protectedRoutes: RegExp[] = [/\/admin(\/.*)?/];
+
+export default async function proxy(req: NextRequest) {
+  // Check if the current route is protected
+  const path = req.nextUrl.pathname;
+  const isProtectedRoute = !!protectedRoutes.find(pattern =>
+    pattern.test(path)
+  );
+
+  // Verify session and redirect if not authenticated
+  if (isProtectedRoute) {
+    try {
+      await verifySession();
+    } catch (e) {
+      // Do not log errors for calling redirect(), this is an expected error.
+      const isRedirectError =
+        typeof e === "object" &&
+        e !== null &&
+        String((e as Record<string, unknown>).digest).includes("NEXT_REDIRECT");
+      if (!isRedirectError) {
+        console.error("Failed to verify session:", e);
+      }
+      // Mock redirects to homepage instead of login page since /login instantly
+      // authenticates the user.
+      return NextResponse.redirect(new URL("/", req.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+// Routes Proxy should not run on
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,38 +1,46 @@
 import { verifySession } from "@/lib/session";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, ProxyConfig } from "next/server";
 
 const protectedRoutes: RegExp[] = [/\/admin(\/.*)?/];
 
-export default async function proxy(req: NextRequest) {
+// The proxy is run before a request is completed.
+// Read more: https://nextjs.org/docs/app/getting-started/proxy
+export default async function proxy(req: NextRequest): Promise<NextResponse> {
   // Check if the current route is protected
   const path = req.nextUrl.pathname;
   const isProtectedRoute = !!protectedRoutes.find(pattern =>
     pattern.test(path)
   );
 
-  // Verify session and redirect if not authenticated
   if (isProtectedRoute) {
+    // Verify session and redirect if not authenticated
     try {
       await verifySession();
     } catch (e) {
-      // Do not log errors for calling redirect(), this is an expected error.
+      // Do not log errors for when redirect() is called in verifySession(), this is an expected error.
       const isRedirectError =
         typeof e === "object" &&
         e !== null &&
         String((e as Record<string, unknown>).digest).includes("NEXT_REDIRECT");
+
       if (!isRedirectError) {
         console.error("Failed to verify session:", e);
       }
-      // Mock redirects to homepage instead of login page since /login instantly
-      // authenticates the user.
+
+      // The mocked authentication redirects to the homepage instead of the
+      // login page since the mocked login would instantly re-authenticate
+      // the user.
       return NextResponse.redirect(new URL("/", req.url));
     }
   }
 
+  // Allow the request to continue as normal
   return NextResponse.next();
 }
 
-// Routes Proxy should not run on
-export const config = {
+// Configure the proxy
+// Read more: https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matcher
+export const config: ProxyConfig = {
+  // Exclude API routes, static files, image optimizations, and .png files
   matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
 };


### PR DESCRIPTION
Referencing the acceptance criteria from #22

## Acceptance criteria

- [x] There should be a "Login" button on the home page.
    `LoginButton` and `LogoutButton` components have been created and a login button has been added to the page header.
- [x] The button should redirect to a placeholder authentication system.
    The authentication system follows a mocked flow similar to the OAuth2 Authentication Code flow, but without validating any actual user credentials.
- [x] After logging in I should be presented a dashboard.
    The dashboard is not added by this pull request but you are redirected to `/admin`, implemented by #26.