### PR TITLE
feat(reviews): anonymous per-client review tracking

### DIFF
--- a/prisma/migrations/20260514113840_add_review_client_id/migration.sql
+++ b/prisma/migrations/20260514113840_add_review_client_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "clientId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Review_clientId_idx" ON "Review"("clientId");

--- a/prisma/migrations/20260514120227_unique_review_per_client_serving/migration.sql
+++ b/prisma/migrations/20260514120227_unique_review_per_client_serving/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Review_clientId_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_clientId_servingId_key" ON "Review"("clientId", "servingId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,9 @@ model Review {
   serving   Serving  @relation(fields: [servingId], references: [id], onDelete: Cascade)
   userId    Int?
   user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  clientId  String?
+
+  @@unique([clientId, servingId])
 }
 
 model Lunch {

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,4 +1,5 @@
 import {
+  ReviewAlreadyExistsError,
   ReviewServingNotFoundError,
   ReviewUserNotFoundError,
   ReviewValidationError,
@@ -41,6 +42,10 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof ReviewServingNotFoundError) {
       return Response.json({ error: error.message }, { status: 404 });
+    }
+
+    if (error instanceof ReviewAlreadyExistsError) {
+      return Response.json({ error: error.message }, { status: 409 });
     }
 
     if (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,30 +3,34 @@
 import { FeedScreen } from "@/components/feed/FeedScreen";
 import { MealSheet } from "@/components/sheet/MealSheet";
 import type { Day, Option, RatingPayload } from "@/lib/types";
-import { addReview, getReviewedServingIds } from "@/services/reviewService";
-import { useEffect, useState } from "react";
+import { addReview, getMyReviewSummaries } from "@/services/reviewService";
+import { useEffect, useMemo, useState } from "react";
 
 type Opened = { option: Option; day: Day };
 
 export default function Home() {
   const [opened, setOpened] = useState<Opened | null>(null);
-  const [ratedIds, setRatedIds] = useState<Set<string>>(new Set());
+  const [myRatings, setMyRatings] = useState<Map<string, number>>(new Map());
 
   useEffect(() => {
     let ignore = false;
 
-    getReviewedServingIds()
-      .then(reviewedServingIds => {
-        if (!ignore) setRatedIds(new Set(reviewedServingIds));
+    getMyReviewSummaries()
+      .then(rows => {
+        if (!ignore) {
+          setMyRatings(new Map(rows.map(r => [r.servingId, r.rating])));
+        }
       })
       .catch(error => {
-        console.log("Failed to fetch reviewed IDs: ", error);
+        console.log("Failed to fetch my reviews: ", error);
       });
 
     return () => {
       ignore = true;
     };
   }, []);
+
+  const ratedIds = useMemo(() => new Set(myRatings.keys()), [myRatings]);
 
   const handleSubmit = async (payload: RatingPayload) => {
     try {
@@ -38,9 +42,9 @@ export default function Home() {
         userId: null,
       });
 
-      setRatedIds(prev => {
-        const next = new Set(prev);
-        next.add(payload.optionId);
+      setMyRatings(prev => {
+        const next = new Map(prev);
+        next.set(payload.optionId, payload.rating);
         return next;
       });
       setOpened(null);
@@ -48,6 +52,10 @@ export default function Home() {
       console.error("Failed to submit rating", error);
     }
   };
+
+  const existingRating = opened
+    ? (myRatings.get(opened.option.id) ?? null)
+    : null;
 
   return (
     <main className="relative">
@@ -58,6 +66,7 @@ export default function Home() {
       <MealSheet
         option={opened?.option ?? null}
         day={opened?.day ?? null}
+        existingRating={existingRating}
         onClose={() => setOpened(null)}
         onSubmit={handleSubmit}
       />

--- a/src/components/sheet/MealSheet.tsx
+++ b/src/components/sheet/MealSheet.tsx
@@ -22,11 +22,18 @@ function getButtonLabel(rating: number, hasExtras: boolean): string {
 type Props = {
   option: Option | null;
   day: Day | null;
+  existingRating: number | null;
   onClose: () => void;
   onSubmit: (payload: RatingPayload) => void;
 };
 
-export function MealSheet({ option, day, onClose, onSubmit }: Props) {
+export function MealSheet({
+  option,
+  day,
+  existingRating,
+  onClose,
+  onSubmit,
+}: Props) {
   const open = option !== null;
   const [display, setDisplay] = useState<{ option: Option; day: Day } | null>(
     null
@@ -63,27 +70,36 @@ export function MealSheet({ option, day, onClose, onSubmit }: Props) {
             <Drawer.Handle className="!bg-ink/15 !h-1 !w-[38px] !rounded-[2px]" />
           </div>
 
-          {display && (
-            <MealSheetContent
-              key={display.option.id}
-              option={display.option}
-              day={display.day}
-              onSubmit={onSubmit}
-            />
-          )}
+          {display &&
+            (existingRating !== null ? (
+              <ReadOnlyView
+                key={display.option.id}
+                option={display.option}
+                day={display.day}
+                rating={existingRating}
+                onClose={onClose}
+              />
+            ) : (
+              <EditableContent
+                key={display.option.id}
+                option={display.option}
+                day={display.day}
+                onSubmit={onSubmit}
+              />
+            ))}
         </Drawer.Content>
       </Drawer.Portal>
     </Drawer.Root>
   );
 }
 
-type ContentProps = {
+type EditableContentProps = {
   option: Option;
   day: Day;
   onSubmit: (payload: RatingPayload) => void;
 };
 
-function MealSheetContent({ option, day, onSubmit }: ContentProps) {
+function EditableContent({ option, day, onSubmit }: EditableContentProps) {
   const [rating, setRating] = useState(0);
   const [tags, setTags] = useState<Set<string>>(new Set());
   const [note, setNote] = useState("");
@@ -239,6 +255,85 @@ function MealSheetContent({ option, day, onSubmit }: ContentProps) {
       </div>
 
       {submitted && <ThankYouView rating={rating} />}
+    </div>
+  );
+}
+
+type ReadOnlyViewProps = {
+  option: Option;
+  day: Day;
+  rating: number;
+  onClose: () => void;
+};
+
+function ReadOnlyView({ option, day, rating, onClose }: ReadOnlyViewProps) {
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div className="relative flex-1 overflow-y-auto">
+        <MealPhoto
+          color={option.color}
+          pattern={option.pattern}
+          height={200}
+          className="mx-4 mt-1 rounded-[20px]"
+        >
+          <LinePill className="absolute top-3 left-3" size="md">
+            {option.line}
+          </LinePill>
+        </MealPhoto>
+
+        <div className="px-5 pt-4.5">
+          <Eyebrow>{formatFeedDate(day.date)}</Eyebrow>
+          <h2
+            className="text-ink mt-1 font-serif"
+            style={{ fontSize: 30, letterSpacing: -0.5, lineHeight: 1.08 }}
+          >
+            {option.name}
+          </h2>
+
+          <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+            {option.tags.map(t => (
+              <Tag key={t}>{t}</Tag>
+            ))}
+            <ClimateTag
+              climate={option.climate}
+              climateLabel={option.climateLabel}
+            />
+          </div>
+
+          <p
+            className="text-ink-muted mt-3.5"
+            style={{ fontSize: 14, lineHeight: 1.5 }}
+          >
+            {option.desc}
+          </p>
+
+          <div className="border-ink/6 bg-paper mt-3.5 rounded-[16px] border p-[18px]">
+            <Eyebrow size="sm" className="block text-center">
+              Your rating
+            </Eyebrow>
+            <div
+              className="mt-3 flex justify-center"
+              aria-label={`You rated ${rating} out of 5`}
+            >
+              <CupRating value={rating} size={46} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="border-ink/6 bg-cream border-t px-5 pt-3.5"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 22px)" }}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className={`bg-ink/10 text-ink w-full cursor-pointer rounded-[14px] font-semibold transition-colors ${FOCUS_RING.cream}`}
+          style={{ fontSize: 14, padding: "15px" }}
+        >
+          Close
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,6 +1,6 @@
 import "server-only";
-import { cookies } from "next/headers";
 import { randomUUID } from "crypto";
+import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
 
 export const CLIENT_ID_COOKIE = "agile_client_id";

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "crypto";
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
 
-export const CLIENT_ID_COOKIE = "agile_client_id";
+export const CLIENT_ID_COOKIE = "client_id";
 
 const CLIENT_ID_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { randomUUID } from "crypto";
+import type { NextRequest, NextResponse } from "next/server";
+
+export const CLIENT_ID_COOKIE = "agile_client_id";
+
+const CLIENT_ID_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const cookieOptions = () => ({
+  httpOnly: true,
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+  path: "/",
+  maxAge: CLIENT_ID_MAX_AGE_SECONDS,
+});
+
+export async function readClientId(): Promise<string | undefined> {
+  const store = await cookies();
+  return store.get(CLIENT_ID_COOKIE)?.value;
+}
+
+export function ensureClientIdOnResponse(
+  req: NextRequest,
+  res: NextResponse
+): string {
+  const existing = req.cookies.get(CLIENT_ID_COOKIE)?.value;
+  const id = existing ?? randomUUID();
+  res.cookies.set(CLIENT_ID_COOKIE, id, cookieOptions());
+  return id;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { ensureClientIdOnResponse } from "@/lib/clientId";
 import { verifySession } from "@/lib/session";
 import { NextRequest, NextResponse, ProxyConfig } from "next/server";
 
@@ -34,8 +35,11 @@ export default async function proxy(req: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Allow the request to continue as normal
-  return NextResponse.next();
+  // Allow the request to continue as normal, ensuring an anonymous client id
+  // cookie is present (and renew its expiry on every visit).
+  const res = NextResponse.next();
+  ensureClientIdOnResponse(req, res);
+  return res;
 }
 
 // Configure the proxy

--- a/src/services/reviewErrors.ts
+++ b/src/services/reviewErrors.ts
@@ -1,3 +1,4 @@
 export class ReviewValidationError extends Error {}
 export class ReviewServingNotFoundError extends Error {}
 export class ReviewUserNotFoundError extends Error {}
+export class ReviewAlreadyExistsError extends Error {}

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -1,7 +1,10 @@
 "use server";
 
+import { Prisma } from "@/generated/prisma/client";
+import { readClientId } from "@/lib/clientId";
 import { prisma } from "@/lib/prisma";
 import {
+  ReviewAlreadyExistsError,
   ReviewServingNotFoundError,
   ReviewUserNotFoundError,
   ReviewValidationError,
@@ -50,29 +53,70 @@ export async function addReview({
     }
   }
 
-  const review = await prisma.review.create({
-    data: {
-      rating,
-      comment: comment?.trim() || null,
-      tags: cleanTags(tags),
-      posted: new Date(),
-      servingId,
-      userId,
-    },
-  });
-  return review;
+  const clientId = (await readClientId()) ?? null;
+
+  if (clientId) {
+    const existing = await prisma.review.findFirst({
+      where: { clientId, servingId },
+      select: { id: true },
+    });
+    if (existing) {
+      throw new ReviewAlreadyExistsError(
+        `serving ${servingId} already reviewed by this client`
+      );
+    }
+  }
+
+  try {
+    return await prisma.review.create({
+      data: {
+        rating,
+        comment: comment?.trim() || null,
+        tags: cleanTags(tags),
+        posted: new Date(),
+        servingId,
+        userId,
+        clientId,
+      },
+    });
+  } catch (e) {
+    // Race condition between the findFirst guard and the create: the DB
+    // unique index catches the duplicate.
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === "P2002"
+    ) {
+      throw new ReviewAlreadyExistsError(
+        `serving ${servingId} already reviewed by this client`
+      );
+    }
+    throw e;
+  }
 }
 
 export async function getAll() {
   return await prisma.review.findMany();
 }
 
-export async function getReviewedServingIds(): Promise<string[]> {
+export async function getMyReviewSummaries(): Promise<
+  { servingId: string; rating: number }[]
+> {
+  const clientId = await readClientId();
+  if (!clientId) return [];
+
   const reviews = await prisma.review.findMany({
-    select: { servingId: true },
+    where: { clientId },
+    select: { servingId: true, rating: true },
+    orderBy: { posted: "desc" },
   });
 
-  return [...new Set(reviews.map(review => review.servingId.toString()))];
+  const seen = new Map<number, number>();
+  for (const r of reviews) if (!seen.has(r.servingId)) seen.set(r.servingId, r.rating);
+
+  return [...seen].map(([servingId, rating]) => ({
+    servingId: servingId.toString(),
+    rating,
+  }));
 }
 
 export async function getReview(id: number) {

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -111,7 +111,8 @@ export async function getMyReviewSummaries(): Promise<
   });
 
   const seen = new Map<number, number>();
-  for (const r of reviews) if (!seen.has(r.servingId)) seen.set(r.servingId, r.rating);
+  for (const r of reviews)
+    if (!seen.has(r.servingId)) seen.set(r.servingId, r.rating);
 
   return [...seen].map(([servingId, rating]) => ({
     servingId: servingId.toString(),


### PR DESCRIPTION
## Summary
- Anonymous clients now get a long-lived `client_id` cookie set by the proxy, so review state can be remembered without an account.
- The feed now fetches the client's full review summaries (servingId + rating) instead of just IDs. Re-opening a rated meal shows a new `ReadOnlyView` in `MealSheet` displaying the previously submitted rating, replacing the editable form.

### Notes
- `clientId` is nullable so legacy rows aren't affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now view their existing ratings for meals in read-only mode.
  * Added prevention of duplicate ratings—users can only rate each meal once.

* **Bug Fixes**
  * Improved error handling when attempting to submit duplicate ratings with a clear conflict message.

* **Chores**
  * Implemented anonymous client tracking to manage user rating history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/olillin/agile-project/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->