### PR TITLE
Add release workflow with tags and GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          name: Don't Spill the Tea ${{ github.tag }}
+          draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
-          name: Don't Spill the Tea ${{ github.tag }}
+          name: Don't Spill the Tea ${{ github.ref_name }}
           draft: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "dont-spill-the-tea",
-  "version": "0.1.0",
-  "private": true,
   "type": "module",
   "scripts": {
     "build": "next build && cp -r public .next/standalone/ && cp -r .next/static .next/standalone/.next/",


### PR DESCRIPTION
This pull request replaces the version and other package information in `package.json` (which is only useful when actually publishing a package to npm) with a semi-automated workflow. When a new tag is pushed matching `v*.*.*` such as `v1.0.0` a new GitHub release is drafted which can be updated with a description and published. This is in addition to a tagged Docker image being built by the already in-place Docker workflow

This makes creating new releases easier as there does not need to be a pull request to bump the version in package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release workflow for publishing versions.
  * Cleaned up package configuration metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/olillin/agile-project/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->